### PR TITLE
Bug fixes to resource management during moves

### DIFF
--- a/circuits/test/circuits/test_check_rsrc.circom
+++ b/circuits/test/circuits/test_check_rsrc.circom
@@ -2,4 +2,4 @@ pragma circom 2.1.1;
 
 include "../../move/move.func.circom";
 
-component main = CheckRsrc(6, 4, 0, 1, 95, 252);
+component main = CheckRsrc(6, 4, 0, 1, 14744269619966411208579211824598458697587494354926760081771325075741142829156, 252);

--- a/game/Player.ts
+++ b/game/Player.ts
@@ -31,6 +31,11 @@ export class Player {
             this.bjjPub = new PubKey(genPubKey(this.bjjPriv.rawPrivKey));
             this.bjjPrivHash = formatPrivKeyForBabyJub(this.bjjPriv.rawPrivKey);
         }
+
+        // If player is the UNOWNED player, then give the designated pub-keys
+        if (symb === "_") {
+            this.bjjPub = new PubKey([BigInt(0), BigInt(0)]);
+        }
     }
 
     static fromPubString(p: string): Player {


### PR DESCRIPTION
For moving onto unowned tiles: unowned tiles now have unique pubKeys, and moving onto unowned tiles captures them.
For moving onto enemies with less resources: moving now captures them.
We also check that player 1) keeps the tile they move from, and 2) cannot pretend to be on an unowned tile.